### PR TITLE
Dev

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -8,11 +8,13 @@ import { IPlayerData } from './players/model/general';
 // ngrx
 import { Store } from '@ngrx/store';
 import * as playersActions from './players/store/players.actions';
+import { NameDestructPipe } from './shared/utils/name-destruct.pipe';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.scss']
+  styleUrls: ['./app.component.scss'],
+  providers: [NameDestructPipe]
 })
 export class AppComponent implements OnInit {
 
@@ -21,42 +23,80 @@ export class AppComponent implements OnInit {
     private router: Router,
     private titleService: Title,
     private store: Store<{ playersGeneral: IPlayerData }>,
+    private nameDestruct: NameDestructPipe,
   ) {}
 
 ngOnInit(): void {
-  let accountId = +this.activatedRoute.snapshot.paramMap.get('id');
-  let currentRoute = this.router?.url?.split('/')[3]?.split('?')[0];
+  // let id = +this.activatedRoute.snapshot.paramMap.get('id'); // heroId, playerAccountId
+  let currentRoute = '';
   currentRoute = currentRoute?.charAt(0).toUpperCase() + currentRoute?.slice(1);
   const initTitle = this.titleService.getTitle();
-  this.getPlayerData(accountId, currentRoute, initTitle);
+  // this.getPlayerData(id, currentRoute, initTitle);
   this.router.events
   .subscribe((event) => {
     if (event instanceof NavigationEnd) {
-      // example url is /players/:id/overview
-      currentRoute = event.url.split('/')[3].split('?')[0]; // Grab last route 'overview'
-      currentRoute = currentRoute.charAt(0).toUpperCase() + currentRoute.slice(1); // last route 'overview' to toUpperCase() first letter
-      // if accountId change will dispatch the player data or won't dispatch
-      if (accountId !== +event.url.split('/')[2].split('?')[0] && currentRoute !== 'overview') {
-        accountId = +event.url.split('/')[2].split('?')[0]; // Grab middle id
-        this.getPlayerData(accountId, currentRoute, initTitle); // Rerun the getPlayerData data
-      }
+      this.titleService.setTitle(`${this.nameDestruct.transform(event?.urlAfterRedirects, '/', 1, 'upperCase', ' - ')} - ${initTitle}`);
+      // // example url is /players/:id/overview
+      // if (event.url?.split('/')[1] === 'players') {
+      //   // Grab last route 'overview'
+      //   currentRoute = event.url?.split('/')[3]?.split('?')[0];
+      //   // last route 'overview' to toUpperCase() first letter
+      //   currentRoute = currentRoute?.charAt(0)?.toUpperCase() + currentRoute?.slice(1);
+      //   // if id change will dispatch the player data or won't dispatch
+      //   if (id !== +event.url?.split('/')[2]?.split('?')[0] || currentRoute !== 'overview') {
+      //     id = +event.url?.split('/')[2]?.split('?')[0]; // Grab middle id
+      //     this.getPlayerData(id, currentRoute, initTitle); // Rerun the getPlayerData data
+      //   }
+      // }
+      // // herees
+      // else if (event.url?.split('/')[1] === 'heroes') {
+      //   // example url is heroes/:id/rankings
+      //   // Grab last route 'rankings'
+      //   currentRoute = event.url?.split('/')[3]?.split('?')[0];
+      //   // last route 'rankings' to toUpperCase() first letter
+      //   currentRoute = currentRoute?.charAt(0)?.toUpperCase() + currentRoute?.slice(1);
+      //   // if heroId change will dispatch the player data or won't dispatch
+      //   if (id !== +event.url?.split('/')[2]?.split('?')[0] || currentRoute !== 'rankings') {
+      //     id = +event.url?.split('/')[2]?.split('?')[0]; // Grab middle id
+      //     this.getHeroData(id, currentRoute, initTitle); // Rerun the getHeroData data
+      //   }
+
+      // }
+      // // other
+      // else {
+      // }
     }
   });
 }
 
-getPlayerData(accountId, currentRoute, initTitle): any {
-  this.store.dispatch(new playersActions.LoadPlayersGeneral(accountId));
-  this.store.select('playersGeneral').subscribe(data => {
-    if (data.player) {
-      if (data?.player?.profile?.name) {
-        this.titleService.setTitle(`${data.player?.profile?.name} - ${currentRoute} - ${initTitle}`);
-      } else {
-        this.titleService.setTitle(`${data.player?.profile?.personaname} - ${currentRoute} - ${initTitle}`);
-      }
-    }
-  }, err => {
-    console.log(err);
-  });
-}
+// getHeroData(id, currentRoute, initTitle): any {
+//   this.store.dispatch(new playersActions.LoadPlayersGeneral(id));
+//   this.store.select('playersGeneral').subscribe(data => {
+//     if (data.player) {
+//       if (data?.player?.profile?.name) {
+//         this.titleService.setTitle(`${data.player?.profile?.name} - ${currentRoute} - ${initTitle}`);
+//       } else {
+//         this.titleService.setTitle(`${data.player?.profile?.personaname} - ${currentRoute} - ${initTitle}`);
+//       }
+//     }
+//   }, err => {
+//     console.log(err);
+//   });
+// }
+
+// getPlayerData(id, currentRoute, initTitle): any {
+//   this.store.dispatch(new playersActions.LoadPlayersGeneral(id));
+//   this.store.select('playersGeneral').subscribe(data => {
+//     if (data.player) {
+//       if (data?.player?.profile?.name) {
+//         this.titleService.setTitle(`${data.player?.profile?.name} - ${currentRoute} - ${initTitle}`);
+//       } else {
+//         this.titleService.setTitle(`${data.player?.profile?.personaname} - ${currentRoute} - ${initTitle}`);
+//       }
+//     }
+//   }, err => {
+//     console.log(err);
+//   });
+// }
 
 }

--- a/src/app/players/components/table-matches/table-matches.component.html
+++ b/src/app/players/components/table-matches/table-matches.component.html
@@ -60,6 +60,22 @@
                 <mat-icon class="party-size-icon">people</mat-icon>
                 <span class="party-size-text">x{{element.party_size}}</span>
               </span>
+
+              <!-- average rank -->
+              <div class="rank-tier" [matTooltip]="element?.average_rank | rankTier" matTooltipPosition="above">
+                <!-- if players in leaderboard rank then no start -->
+                <img
+                onError="this.src='./assets/images/Dota2Logo.svg'"
+                class="rank-start" *ngIf="element?.average_rank !== null && element?.average_rank?.toString()[1] !== '0' && element?.average_rank?.toString()[0] !== '8'" src='https://www.opendota.com/assets/images/dota2/rank_icons/rank_star_{{element?.average_rank?.toString()[1]}}.png' />
+                <!-- 
+                  rank icon if immortal, the icon base on the leaderboar rank
+                  
+                 -->
+                <img
+                onError="this.src='./assets/images/Dota2Logo.svg'"
+                class="rank-icon" src='https://www.opendota.com/assets/images/dota2/rank_icons/rank_icon_{{element?.average_rank !== null ? element?.average_rank?.toString()[0] : "0"}}.png' />
+              </div>
+              <!-- rank tier -->
             </div>
           </div>
         </td>

--- a/src/app/players/components/table-matches/table-matches.component.scss
+++ b/src/app/players/components/table-matches/table-matches.component.scss
@@ -32,6 +32,35 @@
   }
 }
 
+// rank tier
+.rank-tier {
+  position: relative;
+  width: 40px;
+  text-align: center;
+  filter: $dropShadow;
+
+  img {
+    width: 100%;
+
+    &.rank-start {
+      position: absolute;
+    }
+  }
+  
+  .leaderboard-rank {
+    position: absolute;
+    display: inline-block;
+    text-align: center;
+    width: 65px;
+    left: 50%;
+    margin-left: -32px;
+    font-size: 16px;
+    top: 100px;
+    color: $golden;
+    text-shadow: black 0px 0px 10px;
+  }
+}
+
 .ver-align {
   display: flex;
   align-items: center;

--- a/src/app/players/services/players.service.ts
+++ b/src/app/players/services/players.service.ts
@@ -54,7 +54,7 @@ export class PlayersService {
 
   // GET Player matches
   getPlayerMatches(accountId: number, queryParams?: IQuery): Observable<IMatch[]> {
-    return this.generalService.get(`/players/${accountId}/matches?significant=0&project=duration&project=game_mode&project=lobby_type&project=start_time&project=hero_id&project=start_time&project=version&project=kills&project=deaths&project=assists&project=skill&project=leaver_status&project=party_size&project=item_0&project=item_1&project=item_2&project=item_3&project=item_4&project=item_5&project=backpack_0`, queryParams);
+    return this.generalService.get(`/players/${accountId}/matches?significant=0&project=duration&project=game_mode&project=lobby_type&project=start_time&project=hero_id&project=start_time&project=version&project=kills&project=deaths&project=assists&project=skill&project=leaver_status&project=party_size&project=average_rank&project=item_0&project=item_1&project=item_2&project=item_3&project=item_4&project=item_5&project=backpack_0`, queryParams);
   }
 
   // GET player heroes played

--- a/src/app/services/general.service.ts
+++ b/src/app/services/general.service.ts
@@ -31,28 +31,20 @@ export class GeneralService {
     );
   }
 
-  // GET local json data
-  getUser(): Observable<any> {
-    return this.httpClient.get<any>('https://steamloginlv.herokuapp.com/', {
-      headers: {
-        'content-type': 'text/html'
-      },
-      withCredentials: true
-    }).pipe(
-      catchError(this.errorHandle)
-    );
-  }
-
+  // sign in with steam integrate get accountId from localstore and set isLogined
   getAccountId(): any {
     if (!!localStorage.getItem('loginedAccountId')) {
       return this.isLogined.next(true);
     }
     return this.isLogined.next(false);
   }
+
+  // logout and remove the account Id from localstoreage
   getLogout(): any {
     localStorage.removeItem('loginedAccountId');
     return this.isLogined.next(false);
   }
+
   // here get filter query params local json static data
   getLocalData(endpoint): Observable<any> {
     return this.httpClient.get<any>(this.BASE_LOCAL_DATA_URL + endpoint)

--- a/src/app/shared/components/main-nav/main-nav.component.ts
+++ b/src/app/shared/components/main-nav/main-nav.component.ts
@@ -76,11 +76,6 @@ export class MainNavComponent implements OnInit {
     }
   }
 
-  // getUser(): any {
-  //   return this.generalService.getUser().subscribe(user => {
-  //   });
-  // }
-
   logout(): any {
     this.generalService.getLogout();
     this.generalService.isLogined.subscribe(isLogined => this.isLogined = isLogined);

--- a/src/app/shared/utils/name-destruct.pipe.ts
+++ b/src/app/shared/utils/name-destruct.pipe.ts
@@ -5,13 +5,14 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class NameDestructPipe implements PipeTransform {
 
-  transform(value: string, separator: string, separatorPlacement: number, upperCase?: string): unknown {
+  transform(value: string, fromSeparator: string, fromSeparatorPlacement: number, upperCase?: string, toSeparator?: string): unknown {
     // example lobby_type name is lobby_type_normal, we need destruct only last string and uppercase
-    if (value !== null && value.split(separator).length > 1) {
+    if (value !== null && value.split(fromSeparator).length > 1) {
       if (upperCase === 'upperCase') {
-        return value.split(separator).splice(separatorPlacement).map(i => i.charAt(0).toUpperCase() + i.slice(1, i.length)).join(' ');
+        // tslint:disable-next-line:max-line-length
+        return value.split(fromSeparator).splice(fromSeparatorPlacement).map(i => i.charAt(0).toUpperCase() + i.slice(1, i.length)).join(toSeparator ?? ' ');
       } else {
-        return value.split(separator).splice(separatorPlacement).join(' ');
+        return value.split(fromSeparator).splice(fromSeparatorPlacement).join(toSeparator ?? ' ');
       }
     } else {
       return value;

--- a/src/app/shared/utils/rank-tier.pipe.ts
+++ b/src/app/shared/utils/rank-tier.pipe.ts
@@ -8,8 +8,8 @@ export class RankTierPipe implements PipeTransform {
 
   transform(value: unknown, ...args: unknown[]): unknown {
     if (value !== null) {
-      const tier = +value.toString()[0] - 1;
-      const star = value.toString()[1];
+      const tier = +value?.toString()[0] - 1;
+      const star = value?.toString()[1];
       if (tier === 7) {
         // If rank tier is Immortal won't have star num
         return `${this.tierMapping[tier]}`;


### PR DESCRIPTION
Updated browser tab with url route order  
Example: http://localhost:4200/teams/8291895/matches  
![image](https://user-images.githubusercontent.com/4952611/206891549-f36c8ac4-f0d0-4922-96e3-26355a936fa6.png)

Added a toSeparator for name structure pipe  
Then we could change from Separator to Separator  
Example '/teams/8291895/matches' to 'teams - 8291895 - matches'  

Added average rank info for the match table  
![image](https://user-images.githubusercontent.com/4952611/206891631-94e0e62c-5725-4e5c-9e66-2138bbe1adeb.png)
